### PR TITLE
feat: array output

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,17 +119,19 @@ class DependencySizePlugin {
 		deps = _(deps)
 			.toPairs()
 			.orderBy(['1.size'], ['desc'])
-			.map((dep) => {
-				dep[1].size = byteSize(dep[1].size).toString();
-				dep[1].files
+			.map(([dependencyPath, depData]) => {
+				depData.files
 					.sort((a, b) => b.size - a.size)
 					.forEach((f) => {
 						f.size = byteSize(f.size).toString();
 					});
 
-				return dep;
+				return {
+					dependencyPath,
+					size: byteSize(depData.size).toString(),
+					files: depData.files,
+				};
 			})
-			.fromPairs()
 			.value();
 
 		this.writeData(deps, cb);


### PR DESCRIPTION
This changes the output format to be an array instead of an object. This should make it more readable and to-spec (objects have no order).